### PR TITLE
Fix `name` property to match Packagist listing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "planetteamspeak/ts3phpframework",
+  "name": "planetteamspeak/ts3-php-framework",
   "type": "library",
   "description": "Modern use-at-will framework that provides individual components to manage TeamSpeak 3 Server instances",
   "keywords": ["ts3", "teamspeak","server","query","filetransfer","management","interface","api"],


### PR DESCRIPTION
As mentioned by @romanzipp in #8 composer is erroring on invalid Packagist name `planetteamspeak/ts3phpframework`. The correct, corresponding package on Packagist is named `planetteamspeak/ts3-php-framework`.