### PR TITLE
Use string instead of object reference for adapter

### DIFF
--- a/libraries/TeamSpeak3/Transport/Abstract.php
+++ b/libraries/TeamSpeak3/Transport/Abstract.php
@@ -186,7 +186,7 @@ abstract class TeamSpeak3_Transport_Abstract
    */
   public function setAdapter(TeamSpeak3_Adapter_Abstract $adapter)
   {
-    $this->adapter = $adapter;
+    $this->adapter = get_class($adapter);
   }
 
   /**
@@ -208,7 +208,7 @@ abstract class TeamSpeak3_Transport_Abstract
   {
     if($this->adapter instanceof TeamSpeak3_Adapter_Abstract)
     {
-      $string = TeamSpeak3_Helper_String::factory(get_class($this->adapter));
+      $string = TeamSpeak3_Helper_String::factory($this->adapter);
 
       return $string->substr($string->findLast("_"))->replace(array("_", " "), "")->toString();
     }


### PR DESCRIPTION
Fixes cyclic reference issues generalized in #15 and described regarding `TeamSpeak3_Adapter_FileTransfer` in #14.

Testing shows TCP connections close via immediate garbage collection since no cyclic references exist.

Reproduce via PHP CLI using `php -a`:
```php
require_once 'libraries/TeamSpeak3/TeamSpeak3.php';
$ts3_s = TeamSpeak3::factory("serverquery://serveradmin:XXXXXXXX@255.255.255.255:10011/");
$ts3 = $ts3_s->serverGetById(1);

$avatar = $ts3->transferInitDownload(rand(0x0000, 0xFFFF),0,'/avatar_adasfkljasdfkjladfjasdfasdfasfd');
$transfer = TeamSpeak3::factory("filetransfer://255.255.255.255:30033");

echo strlen($transfer->download((string)$avatar["ftkey"], $avatar["size"]));
```
Output:
```
74799
```

Using another tty, check TCP connections using `netstat -peanut | grep 30033`:
```
tcp        0      0 255.255.255.255:60659    255.255.255.255:30033    CLOSE_WAIT  0          1574067932 13090/php
```

Then back in the same PHP CLI session unset and see the garbage collection occurs immediately without needing to manually force `gc_collect_cycles()`:
```php
unset($transfer);
```

Upon checking again with `netstat -peanut | grep 30033`:
```
tcp        0      0 255.255.255.255:30033    255.255.255.255:60659    TIME_WAIT   0          0          -
```

Which times out momentarily after garbage collection.

I'm not sure what the deeper implications of using a (string) vs the (`TeamSpeak3_Adapter_Abstrace`) reference for `TeamSpeak_Transport_Abstract->adapter` are, but upon my testing and searching the code base, I found no other usages that required and active reference to the object itself.

The one exception is the call:
`TeamSpeak3_Helper_Signal::getInstance()->emit(strtolower($this->getAdapterType()) . "WaitTimeout", $time, $this->getAdapter());`
Which seems to always return immediately on:
```php
public function emit($signal, $params = null)
{
  if(!$this->hasHandlers($signal))
  {
    return;
  }
...
```
