### PR TITLE
fixed problem with serverqueryWaitTimeout event

### DIFF
--- a/libraries/TeamSpeak3/Transport/Abstract.php
+++ b/libraries/TeamSpeak3/Transport/Abstract.php
@@ -186,7 +186,7 @@ abstract class TeamSpeak3_Transport_Abstract
    */
   public function setAdapter(TeamSpeak3_Adapter_Abstract $adapter)
   {
-    $this->adapter = get_class($adapter);
+    $this->adapter = $adapter;
   }
 
   /**
@@ -208,7 +208,7 @@ abstract class TeamSpeak3_Transport_Abstract
   {
     if($this->adapter instanceof TeamSpeak3_Adapter_Abstract)
     {
-      $string = TeamSpeak3_Helper_String::factory($this->adapter);
+      $string = TeamSpeak3_Helper_String::factory(get_class($this->adapter));
 
       return $string->substr($string->findLast("_"))->replace(array("_", " "), "")->toString();
     }


### PR DESCRIPTION
An older commit https://github.com/planetteamspeak/ts3phpframework/commit/33616381cd8f5b8442b8c7988ec9e88dca9dae19, where string reference instead of object reference for
the adapter should be used, caused an error.
Until there has been found a better way to fix the cyclic reference stuff the changes should be reverted.