### PR TITLE
HTML Viewer sorts client server group icons by i_group_sort_id

### DIFF
--- a/libraries/TeamSpeak3/Node/Server.php
+++ b/libraries/TeamSpeak3/Node/Server.php
@@ -2413,7 +2413,7 @@ class TeamSpeak3_Node_Server extends TeamSpeak3_Node_Abstract
    * @param  TeamSpeak3_Node_Abstract $b
    * @return integer
    */
-  protected static function sortGroupList(TeamSpeak3_Node_Abstract $a, TeamSpeak3_Node_Abstract $b)
+  public static function sortGroupList(TeamSpeak3_Node_Abstract $a, TeamSpeak3_Node_Abstract $b)
   {
     if(get_class($a) != get_class($b))
     {

--- a/libraries/TeamSpeak3/Viewer/Html.php
+++ b/libraries/TeamSpeak3/Viewer/Html.php
@@ -548,7 +548,25 @@ class TeamSpeak3_Viewer_Html implements TeamSpeak3_Viewer_Interface
       }
     }
 
-    foreach($this->currObj->memberOf() as $group)
+    // Get current groups the client is a member of.
+    // Shift off first group (channel group), leaving only server groups.
+    $groups = $this->currObj->memberOf();
+    $clientGroups = [$groups[0]];
+    unset($groups[0]);
+
+    // Create temp assoc array to use in custom uasort function.
+    $sgroups = [];
+    foreach($groups as $group) {
+      $sgroups[$group['sgid']] = $group;
+    }
+    // Use same server group sort function from TeamSpeak3_Node_Server class.
+    uasort($sgroups, array(get_class($this->currObj->getParent()), "sortGroupList"));
+
+    // Append first group (channel group), convert to non-assoc array.
+    $clientGroups = array_merge($clientGroups, array_values($sgroups));
+    unset($sgroups); // Clean-up temp sorting array.
+
+    foreach($clientGroups as $group)
     {
       if(!$group["iconid"]) continue;
 


### PR DESCRIPTION
See issue #41 for discussion.

Previously, `TeamSpeak3_Viewer_Html` did not sort server group icons, it used the same numerical indexing returned directly by the request `clientlist ... -groups` to teamspeak's server query, which looked like `... client_servergroups=45,66,112,114,116,158 ...`.

The viewer now correctly sorts each set of server groups for each client according to the server group's `i_group_sort_id` property.

The existing sort method `TeamSpeak3_Node_Server::sortGroupList()` is reused in the viewer to sort the server groups.
It sorts first by `i_group_sort_id`, and then by `sgid` (server group id) for any groups with matching sort ids.

Thanks to @Phoenix616 for originally contributing the bug report, we sincerely appreciate the help!
