### PR TITLE
Merge icon order by sort id, fixes #41

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,11 @@
    ! Important - Take note!
 ===============================================================================
 
-=== Release 1.1.24 - 18 Jun 2016 ===
+=== Release 1.1.26 - 18 Jun 2016 ===
+- groups are now correctly sorted by sort id instead of internal id
+- documentation update
+
+=== Release 1.1.25 - 18 Jun 2016 ===
 - fixed PHP 7.1 incompatibile `unset($this)`, fixed by @venyii
 - fixed `serverqueryWaitTimeout` event, reverts #16 (string vs. object
 reference) until cyclic reference fix, fixed by @I-MrFixIt-I 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TeamSpeak 3 PHP Framework
 
-Current Version: **1.1.25**
+Current Version: **1.1.24**
+Current Pre-Release: **1.1.26**
 
 Initially released in January 2010, the TS3 PHP Framework is a powerful, open source, object-oriented framework implemented in PHP 5 and licensed under the GNU General Public License. It’s based on simplicity and a rigorously tested agile codebase. Extend the functionality of your servers with scripts or create powerful web applications to manage all features of your TeamSpeak 3 Server instances.
 


### PR DESCRIPTION
Sort icon order correctly by `i_group_sort_id`. See #43.