### PR TITLE
Fixed type mismatch

### DIFF
--- a/Tests/Helper/StringTest.php
+++ b/Tests/Helper/StringTest.php
@@ -64,4 +64,27 @@ class StringTest extends TestCase
         $this->assertEquals("ello", $string->substr(1, 4));
         $this->assertEquals("world", $string->substr(-6, 5));
     }
+
+    public function testIsInt()
+    {
+        $tests = [
+            "1"     => true,
+            "+1"    => false,
+            "-1"    => false,
+            "hello" => false,
+            "1.0"   => false,
+            ".1"    => false,
+
+            // From https://goo.gl/C5v9wT
+            "0x539"         => false,
+            "0b10100111001" => false,
+            "1337e0"        => false,
+            "9.1"           => false,
+        ];
+
+        foreach ($tests as $test => $expected) {
+            $string = new \TeamSpeak3_Helper_String($test);
+            $this->assertSame($string->isInt(), $expected);
+        }
+    }
 }

--- a/libraries/TeamSpeak3/Helper/String.php
+++ b/libraries/TeamSpeak3/Helper/String.php
@@ -393,7 +393,7 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable
    */
   public function isInt()
   {
-    return (is_numeric($this->string) && !$this->contains(".") && !$this->contains("x")) ? TRUE : FALSE;
+    return ctype_digit($this->string);
   }
 
   /**


### PR DESCRIPTION
Lets say we have groups with names:
```
+10
+20
-10
-20
```
Please note that they start with a arithmetic operator (`+`, `-`)

With this example we get a type mismatch and lose the arithmetic operator:
```php
foreach ($tsServer->serverGroupList() as $group) {
    $name = $group["name"];
    echo "\"$name\" - " . gettype($name) . PHP_EOL;
}
```
Output:
```
"10" - integer    // not as expected, should be "+5" :(
"20" - integer
"10" - integer
"20" - integer
```

With this PR we get the expected output:
```
"+10" - object    // nice!
"+20" - object
"-10" - object
"-20" - object
```
Another great benefit of using `ctype_digit` as in this PR is that we can drop the checks for `.` or `x`.
Also, It would be great to add tests for this case.