### PR TITLE
Updated check for "TLS" on/off

### DIFF
--- a/libraries/TeamSpeak3/Transport/TCP.php
+++ b/libraries/TeamSpeak3/Transport/TCP.php
@@ -54,7 +54,10 @@ class TeamSpeak3_Transport_TCP extends TeamSpeak3_Transport_Abstract
 
     if(!empty($this->config["tls"]))
     {
-      stream_socket_enable_crypto($this->stream, TRUE, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
+      if($this->config["tls"])
+      {
+        stream_socket_enable_crypto($this->stream, TRUE, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
+      }
     }
 
     @stream_set_timeout($this->stream, $timeout);


### PR DESCRIPTION
Instead of checking, if the variable "tls" is empty or not, it's now also checking, if it's set to 1 or not. Only if it's really enabled (`tls=1`), TLS will be enabled.