### PR TITLE
Setup basic compatibility checking. Also polyfill boolval

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,8 @@
     }
   },
   "scripts": {
-    "compatibility": "phpcs -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- libraries/TeamSpeak3"
+    "compatibility": "./vendor/bin/phpcs -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- libraries/TeamSpeak3",
+    "test": "./vendor/bin/phpunit --no-coverage",
+    "coverage": "./vendor/bin/phpunit --no-coverage"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,10 @@
     "satooshi/php-coveralls": "^1.1 || ^2.0",
     "friendsofphp/php-cs-fixer": "^2.0.0",
     "react/socket": "^0.8.5",
-    "symfony/yaml": "~2.1|~3.0|~4.0"
+    "symfony/yaml": "~2.1|~3.0|~4.0",
+    "squizlabs/php_codesniffer": "^3.3",
+    "phpcompatibility/php-compatibility": "^8.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
   },
   "autoload": {
     "files": ["libraries/TeamSpeak3/TeamSpeak3.php"]
@@ -36,5 +39,8 @@
     "psr-4": {
       "Tests\\": "tests"
     }
+  },
+  "scripts": {
+    "compatibility": "phpcs -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- libraries/TeamSpeak3"
   }
 }

--- a/libraries/TeamSpeak3/Helper/String.php
+++ b/libraries/TeamSpeak3/Helper/String.php
@@ -457,7 +457,17 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable
     $pattern[] = "[\xF1-\xF3][\x80-\xBF]{3}";         // planes 4-15
     $pattern[] = "\xF4[\x80-\x8F][\x80-\xBF]{2}";     // plane 16
 
-    return boolval(preg_match("%(?:" . implode("|", $pattern) . ")+%xs", $this->string));
+    $match_result = preg_match("%(?:" . implode("|", $pattern) . ")+%xs", $this->string);
+
+    // boolval is not supported in PHP 5.5 and below.
+    if (!function_exists('boolval')) {
+        function boolval($val) {
+            return (bool) $val;
+        }
+    }
+
+    // phpcs:ignore PHPCompatibility.PHP.NewFunctions.boolvalFound -- Pollyfilled above
+    return boolval($match_result);
   }
 
   /**

--- a/libraries/TeamSpeak3/Helper/String.php
+++ b/libraries/TeamSpeak3/Helper/String.php
@@ -457,17 +457,7 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable
     $pattern[] = "[\xF1-\xF3][\x80-\xBF]{3}";         // planes 4-15
     $pattern[] = "\xF4[\x80-\x8F][\x80-\xBF]{2}";     // plane 16
 
-    $match_result = preg_match("%(?:" . implode("|", $pattern) . ")+%xs", $this->string);
-
-    // boolval is not supported in PHP 5.5 and below.
-    if (!function_exists('boolval')) {
-        function boolval($val) {
-            return (bool) $val;
-        }
-    }
-
-    // phpcs:ignore PHPCompatibility.PHP.NewFunctions.boolvalFound -- Pollyfilled above
-    return boolval($match_result);
+    return (bool) preg_match("%(?:" . implode("|", $pattern) . ")+%xs", $this->string);
   }
 
   /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,12 +10,7 @@ if (!file_exists($file)) {
 
 $autoload = require_once $file;
 
-$parsed_phpunit_version = `./vendor/bin/phpunit --version | head -n 1 | tr ' ' '\n' | head -n 2 | tail -n 1 | head -c 1`;
-if (!is_null($parsed_phpunit_version) && $parsed_phpunit_version < 6) {
-    class_alias('PHPUnit_Framework_Constraint_IsType', 'PHPUnit\Framework\Constraint\IsType');
-}
-
 // Make PHPUnit 6 tests backward compatible for PHPUnit 5 code base
-if (PHP_VERSION_ID < 70000) {
+if (PHP_VERSION_ID < 70000 || PHPUnit_Runner_Version::id() < 6) {
   class_alias('PHPUnit_Framework_Constraint_IsType', 'PHPUnit\Framework\Constraint\IsType');
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,11 @@ if (!file_exists($file)) {
 
 $autoload = require_once $file;
 
+$parsed_phpunit_version = `./vendor/bin/phpunit --version | head -n 1 | tr ' ' '\n' | head -n 2 | tail -n 1 | head -c 1`;
+if (!is_null($parsed_phpunit_version) && $parsed_phpunit_version < 6) {
+    class_alias('PHPUnit_Framework_Constraint_IsType', 'PHPUnit\Framework\Constraint\IsType');
+}
+
 // Make PHPUnit 6 tests backward compatible for PHPUnit 5 code base
 if (PHP_VERSION_ID < 70000) {
   class_alias('PHPUnit_Framework_Constraint_IsType', 'PHPUnit\Framework\Constraint\IsType');


### PR DESCRIPTION
Added a couple `composer` dev requirements, and a `compatibility` script to `composer.json`. Now running `composer compatibility` will report on any code incompatibilities down to the specified PHP version (I've set it to 5.2 for now).

I also added a polyfill for the `boolval` global, as well as a comment to disable compatibility error for the applicable line; this will run without errors on PHP 5.2 and up, and prevents `composer compatibility` from reporting an error for that violation.