### PR TITLE
TeamSpeak3_Helper_String::contains() now quotes regex delimiter

### DIFF
--- a/libraries/TeamSpeak3/Helper/String.php
+++ b/libraries/TeamSpeak3/Helper/String.php
@@ -186,7 +186,7 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable, Json
 
     if($regexp)
     {
-      return (preg_match("/" . $pattern . "/i", $this->string)) ? TRUE : FALSE;
+      return (preg_match("/" . preg_quote($pattern, '/') . "/i", $this->string)) ? TRUE : FALSE;
     }
     else
     {


### PR DESCRIPTION
Fixes PHP notice when a user forgets to escape delimiter when passing TeamSpeak3_Helper_String::contains() a regex pattern.
Resolves part of #127.