### PR TITLE
Fixing deprecated curly braces for PHP 7.4+

### DIFF
--- a/libraries/TeamSpeak3/Helper/Char.php
+++ b/libraries/TeamSpeak3/Helper/Char.php
@@ -179,7 +179,7 @@ class TeamSpeak3_Helper_Char
    */
   public function toUnicode()
   {
-    $h = ord($this->char{0});
+    $h = ord($this->char[0]);
 
     if($h <= 0x7F)
     {
@@ -191,15 +191,15 @@ class TeamSpeak3_Helper_Char
     }
     else if($h <= 0xDF)
     {
-      return ($h & 0x1F) << 6 | (ord($this->char{1}) & 0x3F);
+      return ($h & 0x1F) << 6 | (ord($this->char[1]) & 0x3F);
     }
     else if($h <= 0xEF)
     {
-      return ($h & 0x0F) << 12 | (ord($this->char{1}) & 0x3F) << 6 | (ord($this->char{2}) & 0x3F);
+      return ($h & 0x0F) << 12 | (ord($this->char[1]) & 0x3F) << 6 | (ord($this->char[2]) & 0x3F);
     }
     else if($h <= 0xF4)
     {
-      return ($h & 0x0F) << 18 | (ord($this->char{1}) & 0x3F) << 12 | (ord($this->char{2}) & 0x3F) << 6 | (ord($this->char{3}) & 0x3F);
+      return ($h & 0x0F) << 18 | (ord($this->char[1]) & 0x3F) << 12 | (ord($this->char[2]) & 0x3F) << 6 | (ord($this->char[3]) & 0x3F);
     }
     else
     {

--- a/libraries/TeamSpeak3/Helper/Crypt.php
+++ b/libraries/TeamSpeak3/Helper/Crypt.php
@@ -174,7 +174,7 @@ class TeamSpeak3_Helper_Crypt
       $data = 0;
       for($j = 4; $j > 0; $j--)
       {
-        $data = $data << 8 | ord($passphrase{$k});
+        $data = $data << 8 | ord($passphrase[$k]);
         $k = ($k+1) % $length;
       }
       $this->p[$i] ^= $data;

--- a/libraries/TeamSpeak3/Helper/String.php
+++ b/libraries/TeamSpeak3/Helper/String.php
@@ -921,7 +921,7 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable, Json
    */
   public function offsetGet($offset)
   {
-    return ($this->offsetExists($offset)) ? new TeamSpeak3_Helper_Char($this->string{$offset}) : null;
+    return ($this->offsetExists($offset)) ? new TeamSpeak3_Helper_Char($this->string[$offset]) : null;
   }
 
   /**
@@ -931,7 +931,7 @@ class TeamSpeak3_Helper_String implements ArrayAccess, Iterator, Countable, Json
   {
     if(!$this->offsetExists($offset)) return;
 
-    $this->string{$offset} = strval($value);
+    $this->string[$offset] = strval($value);
   }
 
   /**

--- a/libraries/TeamSpeak3/Node/Host.php
+++ b/libraries/TeamSpeak3/Node/Host.php
@@ -539,7 +539,7 @@ class TeamSpeak3_Node_Host extends TeamSpeak3_Node_Abstract
       $permtree[$val]["permcatid"]      = $val;
       $permtree[$val]["permcathex"]     = "0x" . dechex($val);
       $permtree[$val]["permcatname"]    = TeamSpeak3_Helper_String::factory(TeamSpeak3_Helper_Convert::permissionCategory($val));
-      $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"]{3} == 0 ? 0 : hexdec($permtree[$val]["permcathex"]{2} . 0);
+      $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"][3] == 0 ? 0 : hexdec($permtree[$val]["permcathex"][2] . 0);
       $permtree[$val]["permcatchilren"] = 0;
       $permtree[$val]["permcatcount"]   = 0;
 


### PR DESCRIPTION
Fixing PHP 7.4 Deprecated: Array and string offset access syntax with curly braces is deprecated (ticket #141)