### PR TITLE
Dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ install:
   - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction
 
 before_script:
+  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
+  - pecl install -f ssh2-beta < .noninteractive
   - mkdir -p "$HOME/.php-cs-fixer"
   - cp phpunit.xml.dist phpunit.xml
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server
-  - if [[ $TRAVIS_PHP_VERSION > 7 ]]; then if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-1.2; fi else if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-0.13; fi fi
+  - if [[ $(php -r "echo PHP_VERSION;") > 7 ]]; then if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-1.2; fi else if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-0.13; fi fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,18 +35,6 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.php-cs-fixer
 
-before_install:
-  - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
-  - docker ps -a
-  - docker logs teamspeak_server
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - travis_retry composer self-update
-
-install:
-  - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction
-
 before_script:
   - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
   - pecl install -f ssh2-beta < .noninteractive
@@ -61,6 +49,18 @@ script:
   - if [[ $COVERAGE == yes ]]; then vendor/bin/phpunit --coverage-text; else vendor/bin/phpunit --no-coverage; fi
   - if [[ $EXECUTE_CS_CHECK == yes ]]; then php -n -d memory_limit=768M vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --dry-run; fi
   - if [[ $COVERAGE == yes ]] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+
+before_install:
+  - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
+  - docker ps -a
+  - docker logs teamspeak_server
+  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - travis_retry composer self-update
+
+install:
+  - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ before_install:
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server
-  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
-  - pecl install -f ssh2-beta < .noninteractive
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
@@ -50,6 +48,8 @@ install:
   - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction
 
 before_script:
+  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
+  - pecl install -f ssh2-beta < .noninteractive
   - mkdir -p "$HOME/.php-cs-fixer"
   - cp phpunit.xml.dist phpunit.xml
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server
+  - pecl install ssh2
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
@@ -48,8 +49,6 @@ install:
   - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction
 
 before_script:
-  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
-  - pecl install -f ssh2-beta < .noninteractive
   - mkdir -p "$HOME/.php-cs-fixer"
   - cp phpunit.xml.dist phpunit.xml
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server
-  - pecl install ssh2
+  - if [[ $TRAVIS_PHP_VERSION > 7 ]]; then if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-1.2; fi else if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-0.13; fi fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ before_install:
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server
-  - if [[ $(php -r "echo PHP_VERSION;") > 7 ]]; then if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-1.2; fi else if [[ $(pecl list | grep -Eoc "ssh2") -eq 0 ]]; then pecl install ssh2-0.13; fi fi
+  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
+  - pecl install -f ssh2-beta < .noninteractive
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,20 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
   - nightly
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.4
       env: COVERAGE=yes
-    - php: 7.2
+    - php: 7.4
       env: EXECUTE_CS_CHECK=yes
   fast_finish: true
   allow_failures:
     - php: nightly
-    - php: 7.2
+    - php: 7.4
       env: EXECUTE_CS_CHECK=yes
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_script:
-  - sudo apt-get install -y php-pear
-  - sudo pear channel-discover phpseclib.sourceforge.net
-  - sudo pear remote-list -c phpseclib
-  - sudo pear install phpseclib/Net_SSH2
   - mkdir -p "$HOME/.php-cs-fixer"
   - cp phpunit.xml.dist phpunit.xml
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -53,6 +49,10 @@ script:
   - if [[ $COVERAGE == yes ]] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
 
 before_install:
+  - sudo apt-get install -y php-pear
+  - sudo pear channel-discover phpseclib.sourceforge.net
+  - sudo pear remote-list -c phpseclib
+  - sudo pear install phpseclib/Net_SSH2
   - docker run -d --name="teamspeak_server" -p "9987:9987/udp" -p 10011:10011 -p 30033:30033 teamspeak:latest
   - docker ps -a
   - docker logs teamspeak_server

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_script:
-  - sudo apt-get install -y -qq libssh2-1-dev libssh2-php
-  - pecl install -f ssh2-beta < .noninteractive
+  - sudo apt-get install -y php-pear
+  - sudo pear channel-discover phpseclib.sourceforge.net
+  - sudo pear remote-list -c phpseclib
+  - sudo pear install phpseclib/Net_SSH2
   - mkdir -p "$HOME/.php-cs-fixer"
   - cp phpunit.xml.dist phpunit.xml
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,9 +9,11 @@
    ! Important - Take note!
 ===============================================================================
 
-=== Release 1.1.34 - WIP ===
+=== Release 1.1.34 - 04 Mar 2020 ===
  ! upgrading your servers to 3.10.0 (build >= 1564054246) is mandatory
  + added optional -continueonerror argument to some commands
+ + added optional -keepfiles argument to serversnapshotdeploy command
+ + added optional -banners argument to channellist command
  + added pagination support for banlist commands
  + added management support for ServerQuery logins
  * property client_nickname will now be set before selecting a virtual server

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TeamSpeak 3 PHP Framework
 
+[![Build Status](https://travis-ci.org/planetteamspeak/ts3phpframework.svg?branch=master)](https://travis-ci.org/planetteamspeak/ts3phpframework)
+
 Initially released in January 2010, the TS3 PHP Framework is a powerful, open source, object-oriented framework implemented in PHP 5 and licensed under the GNU General Public License. It’s based on simplicity and a rigorously tested agile codebase. Extend the functionality of your servers with scripts or create powerful web applications to manage all features of your TeamSpeak 3 Server instances.
 
 Tested. Thoroughly. Enterprise-ready and built with agile methods, the TS3 PHP Framework has been unit-tested from the start to ensure that all code remains stable and easy for you to extend, re-test with your extensions, and further maintain.
@@ -28,7 +30,7 @@ Speed up new development and reduce maintenance costs by using this nifty piece 
 
 **Requirements**
 
-* PHP - Developed on PHP 7.x, with 7.2.x targeted for testing.
+* PHP - Developed on PHP 7.x, with 7.4.x targeted for testing.
 * TeamSpeak Server - v3.4.0 (build >= 1536564584) or higher.
 
 **Often used with...**
@@ -54,7 +56,7 @@ composer require planetteamspeak/ts3-php-framework:dev-master
 
 ### Tests
 
-To run all tests use `php vendor/bin/phpunit`.
+To run all tests use `composer run tests`.
 
 ### Useful Links
 
@@ -248,6 +250,10 @@ For further information please visit the documentation (see [Useful Links](#usef
 Setup a local test instance of TeamSpeak3 (amd64, Alpine Linux):
 ```
 docker run --name teamspeak_server -p 9987:9987/udp -p 10011:10011 -p 30033:30033 -e TS3SERVER_LICENSE=accept teamspeak:latest
+```
+Or simply start the predefined docker container `docker-compose.yml`:
+```
+docker-compose up
 ```
 _Add `-d` flag to run in background. Options / Examples: [Docs @ Docker](https://docs.docker.com/samples/library/teamspeak/) | [Hub @ Docker](https://hub.docker.com/_/teamspeak/)_
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": ">=5.6",
     "ext-json": "*",
     "ext-ctype": "*",
-    "phpseclib/phpseclib": "*",
+    "phpseclib/phpseclib": "^1.0",
     "ext-openssl": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
     "ext-openssl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0",
-    "satooshi/php-coveralls": "^1.1 || ^2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "friendsofphp/php-cs-fixer": "^2.0.0",
-    "react/socket": "^0.8.5",
-    "symfony/yaml": "~2.1|~3.0|~4.0",
-    "squizlabs/php_codesniffer": "^3.3",
+    "php-coveralls/php-coveralls": "^2.2",
     "phpcompatibility/php-compatibility": "^8.2",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+    "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0",
+    "react/socket": "^0.8.5",
+    "squizlabs/php_codesniffer": "^3.3",
+    "symfony/yaml": "~2.1|~3.0|~4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "issues": "https://github.com/planetteamspeak/ts3phpframework/issues",
     "docs": "https://docs.planetteamspeak.com/ts3/php/framework"
   },
+  "config": {
+    "sort-packages": true
+  },
   "require": {
     "php": ">=5.6",
     "ext-json": "*",
@@ -35,13 +38,19 @@
   },
   "autoload": {
     "psr-4": {
-      "PlanetTeamSpeak\\TeamSpeak3Framework\\": "src/",
+      "PlanetTeamSpeak\\TeamSpeak3Framework\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "PlanetTeamSpeak\\TeamSpeak3Framework\\Tests\\": "tests/"
     }
   },
   "scripts": {
-    "compatibility": "./vendor/bin/phpcs -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- src",
-    "test": "./vendor/bin/phpunit --no-coverage ./tests",
-    "coverage": "./vendor/bin/phpunit"
+    "compatibility": "\"vendor/bin/phpcs\" -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- src",
+    "tests": [
+      "\"vendor/bin/phpunit\" --no-coverage"
+    ],
+    "coverage": "\"vendor/bin/phpunit\""
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": ">=5.6",
     "ext-json": "*",
     "ext-ctype": "*",
-    "ext-ssh2": "*",
+    "phpseclib/phpseclib": "*",
     "ext-openssl": "*"
   },
   "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - 9987:9987/udp
       - 10011:10011
+      - 10022:10022
       - 30033:30033
     environment:
       TS3SERVER_DB_PLUGIN: ts3db_mariadb

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
   <testsuites>
     <testsuite name="Teamspeak 3 PHP Framework Test Suite">
@@ -18,7 +17,7 @@
 
   <logging>
     <log type="coverage-clover" target="build/logs/clover.xml"/>
-    <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+    <log type="junit" target="build/logs/junit.xml"/>
   </logging>
 
   <filter>

--- a/src/Helper/Char.php
+++ b/src/Helper/Char.php
@@ -183,18 +183,18 @@ class Char
      */
     public function toUnicode()
     {
-        $h = ord($this->char{0});
+        $h = ord($this->char[0]);
 
         if ($h <= 0x7F) {
             return $h;
         } elseif ($h < 0xC2) {
             return false;
         } elseif ($h <= 0xDF) {
-            return ($h & 0x1F) << 6 | (ord($this->char{1}) & 0x3F);
+            return ($h & 0x1F) << 6 | (ord($this->char[1]) & 0x3F);
         } elseif ($h <= 0xEF) {
-            return ($h & 0x0F) << 12 | (ord($this->char{1}) & 0x3F) << 6 | (ord($this->char{2}) & 0x3F);
+            return ($h & 0x0F) << 12 | (ord($this->char[1]) & 0x3F) << 6 | (ord($this->char[2]) & 0x3F);
         } elseif ($h <= 0xF4) {
-            return ($h & 0x0F) << 18 | (ord($this->char{1}) & 0x3F) << 12 | (ord($this->char{2}) & 0x3F) << 6 | (ord($this->char{3}) & 0x3F);
+            return ($h & 0x0F) << 18 | (ord($this->char[1]) & 0x3F) << 12 | (ord($this->char[2]) & 0x3F) << 6 | (ord($this->char[3]) & 0x3F);
         } else {
             return false;
         }

--- a/src/Helper/Crypt.php
+++ b/src/Helper/Crypt.php
@@ -171,7 +171,7 @@ class Crypt
         for ($i = 0; $i < 18; $i++) {
             $data = 0;
             for ($j = 4; $j > 0; $j--) {
-                $data = $data << 8 | ord($passphrase{$k});
+                $data = $data << 8 | ord($passphrase[$k]);
                 $k = ($k + 1) % $length;
             }
             $this->p[$i] ^= $data;

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -883,7 +883,7 @@ class StringHelper implements \ArrayAccess, \Iterator, \Countable, \JsonSerializ
      */
     public function current()
     {
-        return new Char($this->string{$this->position});
+        return new Char($this->string[$this->position]);
     }
 
     /**
@@ -907,7 +907,7 @@ class StringHelper implements \ArrayAccess, \Iterator, \Countable, \JsonSerializ
      */
     public function offsetGet($offset)
     {
-        return ($this->offsetExists($offset)) ? new Char($this->string{$offset}) : null;
+        return ($this->offsetExists($offset)) ? new Char($this->string[$offset]) : null;
     }
 
     /**
@@ -919,7 +919,7 @@ class StringHelper implements \ArrayAccess, \Iterator, \Countable, \JsonSerializ
             return;
         }
 
-        $this->string{$offset} = strval($value);
+        $this->string[$offset] = strval($value);
     }
 
     /**

--- a/src/Node/Host.php
+++ b/src/Node/Host.php
@@ -543,7 +543,7 @@ class Host extends Node
             $permtree[$val]["permcatid"]      = $val;
             $permtree[$val]["permcathex"]     = "0x" . dechex($val);
             $permtree[$val]["permcatname"]    = StringHelper::factory(Convert::permissionCategory($val));
-            $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"]{3} == 0 ? 0 : hexdec($permtree[$val]["permcathex"]{2} . 0);
+            $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"][3] == 0 ? 0 : hexdec($permtree[$val]["permcathex"][2] . 0);
             $permtree[$val]["permcatchilren"] = 0;
             $permtree[$val]["permcatcount"]   = 0;
 


### PR DESCRIPTION
- Merged `master` into `dev`
- Added Travis CI build status icon to README
- Travis CI tests now also PHP 7.3 and 7.4
- Improved composer.json
- Updated command to run all tests in README
- Added `docker-compose up` to README for existing docker container(s)
- Fixed PHPUnit config issues
- Replaced required PHP extension "ssh2" (`libssh2`) with `phpseclib`
- PHP 7.4: Replaced deprecated curly braces with square braces
- Replaced abandoned package `satooshi/php-coveralls`  with `php-coveralls/php-coveralls`
- Updated composer packages