### PR TITLE
Removed deprecated curly braces

### DIFF
--- a/libraries/TeamSpeak3/Node/Host.php
+++ b/libraries/TeamSpeak3/Node/Host.php
@@ -594,7 +594,7 @@ class TeamSpeak3_Node_Host extends TeamSpeak3_Node_Abstract
       $permtree[$val]["permcatid"]      = $val;
       $permtree[$val]["permcathex"]     = "0x" . dechex($val);
       $permtree[$val]["permcatname"]    = TeamSpeak3_Helper_String::factory(TeamSpeak3_Helper_Convert::permissionCategory($val));
-      $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"]{3} == 0 ? 0 : hexdec($permtree[$val]["permcathex"]{2} . 0);
+      $permtree[$val]["permcatparent"]  = $permtree[$val]["permcathex"][3] == 0 ? 0 : hexdec($permtree[$val]["permcathex"][2] . 0);
       $permtree[$val]["permcatchilren"] = 0;
       $permtree[$val]["permcatcount"]   = 0;
 


### PR DESCRIPTION
Fixes Decprecated error on PHP 7.4+:
`PHP Deprecated: Array and string offset access syntax with curly braces is deprecated in /ts3-php-framework/libraries/TeamSpeak3/Node/Host.php:597`