### PR TITLE
Fix adapter instantiating for deviating directory seperators

### DIFF
--- a/src/TeamSpeak3.php
+++ b/src/TeamSpeak3.php
@@ -353,7 +353,7 @@ class TeamSpeak3
             $options["password"] = $uri->getPass();
         }
 
-        $adapterClass = "PlanetTeamSpeak\\TeamSpeak3Framework\\" . $adapter;
+        $adapterClass = "PlanetTeamSpeak\\TeamSpeak3Framework\\" . str_replace(DIRECTORY_SEPARATOR, "\\", $adapter);
 
         $object = new $adapterClass($options);
 


### PR DESCRIPTION
Solve #163 by replacing occurring directory separators with a backslash.