### PR TITLE
Implement PHPUnit Github workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,37 @@
+name: "PHPUnit"
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 15 * * 2'
+
+jobs:
+  phpunit-tests:
+    strategy:
+      matrix:
+        php_versions: [
+          '8.0',
+          '8.1',
+          '8.2',
+        ]
+    name: PHP ${{ matrix.php_versions }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+
+    - name: install dependencies
+      uses: php-actions/composer@v6
+
+    - name: run phpunit tests
+      uses: php-actions/phpunit@v3
+      with:
+        php_version: ${{ matrix.php_versions }}
+        php_extensions: openssl ssh2
+        configuration: ./phpunit.xml.dist
+        memory_limit: 256M
+        bootstrap: tests\bootstrap.php

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TeamSpeak 3 PHP Framework
 
+[![PHPUnit Tests](/actions/workflows/phpunit.yml/badge.svg?branch=master)](/actions/workflows/phpunit.yml?query=branch%3Amaster)
+
 Initially released in January 2010, the TS3 PHP Framework is a powerful, open source, object-oriented framework implemented in PHP 5 and licensed under the GNU General Public License. It’s based on simplicity and a rigorously tested agile codebase. Extend the functionality of your servers with scripts or create powerful web applications to manage all features of your TeamSpeak 3 Server instances.
 
 Tested. Thoroughly. Enterprise-ready and built with agile methods, the TS3 PHP Framework has been unit-tested from the start to ensure that all code remains stable and easy for you to extend, re-test with your extensions, and further maintain.

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "php": ">=5.2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0",
-    "satooshi/php-coveralls": "^1.1 || ^2.0",
+    "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0 || ^10.0",
+    "php-coveralls/php-coveralls": "^1.1 || ^2.0 || ^2.5",
     "friendsofphp/php-cs-fixer": "^2.0.0",
     "react/socket": "^0.8.5",
     "symfony/yaml": "~2.1|~3.0|~4.0",
     "squizlabs/php_codesniffer": "^3.3",
     "phpcompatibility/php-compatibility": "^8.2",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.7.0"
   },
   "autoload": {
     "files": ["libraries/TeamSpeak3/TeamSpeak3.php"]

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
     "compatibility": "./vendor/bin/phpcs -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 5.2- libraries/TeamSpeak3",
     "test": "./vendor/bin/phpunit --no-coverage",
     "coverage": "./vendor/bin/phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/tests/Unit/Helper/SignalTest.php
+++ b/tests/Unit/Helper/SignalTest.php
@@ -20,7 +20,8 @@ class SignalTest extends TestCase
   protected static $callback = __CLASS__ . '::onEvent';
   protected static $testString = '!@w~//{tI_8G77<qS+g*[Gb@u`pJ^2>rO*f=KS:8Yj';
   
-  protected function setUp() {
+  protected function setUp(): void
+  {
     static::$cTriggers = [];
     foreach(TS3_Signal::getInstance()->getSignals() as $signal)
       TS3_Signal::getInstance()->clearHandlers($signal);
@@ -152,4 +153,3 @@ class SignalTest extends TestCase
     return $data;
   }
 }
-


### PR DESCRIPTION
Yeah... The title says already everything.

This change should run the already existing PHPUnit tests as Github workflow. :D

```shell
$ php vendor/bin/phpunit
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

..R.RRRRRRRRRRREEEEEE.EERRRRR.........EE.E.....................  63 / 114 ( 55%)
.........R..RR........E.E.E..E..FF.FFFFE..E..EFE.FF             114 / 114 (100%)

Time: 00:20.975, Memory: 10.00 MB

[...]

ERRORS!
Tests: 114, Assertions: 499, Errors: 19, Failures: 9, Risky: 20.
```

Documentation: https://github.com/marketplace/actions/phpunit-php-actions