### PR TITLE
Implement PHPUnit GitHub workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,37 @@
+name: "PHPUnit"
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 15 * * 2'
+
+jobs:
+  phpunit-tests:
+    strategy:
+      matrix:
+        php_versions: [
+          '8.0',
+          '8.1',
+          '8.2',
+        ]
+    name: PHP ${{ matrix.php_versions }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+
+    - name: install dependencies
+      uses: php-actions/composer@v6
+
+    - name: run phpunit tests
+      uses: php-actions/phpunit@v3
+      with:
+        php_version: ${{ matrix.php_versions }}
+        php_extensions: openssl ssh2
+        configuration: ./phpunit.xml.dist
+        memory_limit: 256M
+        bootstrap: tests\bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
     "ext-openssl": "*"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-    "friendsofphp/php-cs-fixer": "^2.0.0",
-    "php-coveralls/php-coveralls": "^2.2",
-    "phpcompatibility/php-compatibility": "^8.2",
-    "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0",
-    "react/socket": "^0.8.5",
-    "squizlabs/php_codesniffer": "^3.3",
-    "symfony/yaml": "~2.1|~3.0|~4.0"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+    "friendsofphp/php-cs-fixer": "^3.8",
+    "php-coveralls/php-coveralls": "^2.5",
+    "phpcompatibility/php-compatibility": "^9.3",
+    "phpunit/phpunit": "^9.5",
+    "react/socket": "^1.11",
+    "squizlabs/php_codesniffer": "^3.6",
+    "symfony/yaml": "^6.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
     "docs": "https://docs.planetteamspeak.com/ts3/php/framework"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "require": {
     "php": ">=5.6",

--- a/tests/Helper/SignalTest.php
+++ b/tests/Helper/SignalTest.php
@@ -17,7 +17,7 @@ class SignalTest extends TestCase
     protected static $callback = __CLASS__ . '::onEvent';
     protected static $testString = '!@w~//{tI_8G77<qS+g*[Gb@u`pJ^2>rO*f=KS:8Yj';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         static::$cTriggers = [];
         foreach (Signal::getInstance()->getSignals() as $signal) {


### PR DESCRIPTION
Yeah... The title says already everything.

This change should run the already existing PHPUnit tests as Github workflow. :D

```shell
$ php vendor/bin/phpunit
PHPUnit 10.0.7 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.2
Configuration: C:\Users\Sebastian\Downloads\ts3phpframework\phpunit.xml.dist

..R.RRRRRRRRRRREEEEEE.EERRRRR.........EE.E.....................  63 / 114 ( 55%)
.........R..RR........E.E.E..E..FF.FFFFE..E..EFE.FF             114 / 114 (100%)

Time: 00:20.406, Memory: 10.00 MB

[...]

ERRORS!
Tests: 114, Assertions: 499, Errors: 19, Failures: 9, Warnings: 1, Risky: 20.
```

Documentation: https://github.com/marketplace/actions/phpunit-php-actions