### PR TITLE
Remove `bootstrap` option from workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,4 +34,3 @@ jobs:
         php_extensions: openssl ssh2
         configuration: ./phpunit.xml.dist
         memory_limit: 256M
-        bootstrap: tests\bootstrap.php


### PR DESCRIPTION
There is no `bootstrap` file anymore on the `dev` branch, so we need to remove this as the workflow fails otherwise.