### PR TITLE
Migrate PHPUnit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Build related
 build/
 .php_cs.cache
+.phpunit.result.cache
 
 # OS-specific
 .DS_Store

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,28 +7,29 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./images</directory>
+      <directory>./public</directory>
+      <directory>./tests</directory>
+      <directory>./build</directory>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="Teamspeak 3 PHP Framework Test Suite">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
-
   <logging>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-    <log type="junit" target="build/logs/junit.xml"/>
+    <junit outputFile="build/logs/junit.xml"/>
   </logging>
-
-  <filter>
-    <whitelist>
-      <directory>./</directory>
-      <exclude>
-        <directory>./images</directory>
-        <directory>./public</directory>
-        <directory>./tests</directory>
-        <directory>./build</directory>
-        <directory>./vendor</directory>
-      </exclude>
-    </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
Fixes the following PHPUnit warning:

> Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

...which also automatically solves a some PHPUnit issues.