### PR TITLE
Add code-style script to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "compatibility": "\"vendor/bin/phpcs\" -ps --basepath=. --standard=PHPCompatibility --runtime-set testVersion 8.0- src",
+    "code-style": "\"vendor/bin/php-cs-fixer\" fix --config .php-cs-fixer.php --diff",
     "tests": [
       "\"vendor/bin/phpunit\" --no-coverage"
     ],


### PR DESCRIPTION
Since I'm using PHP 8.2 on my local machine, I had to set `PHP_CS_FIXER_IGNORE_ENV=1`, but it seems to work in general:
```
$ PHP_CS_FIXER_IGNORE_ENV=1 composer run code-style
> "vendor/bin/php-cs-fixer" fix --config .php-cs-fixer.php --diff
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.2.2.
Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.2.2.
Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.

Fixed 0 of 52 files in 0.006 seconds, 14.000 MB memory used
Loaded config default from ".php-cs-fixer.php".
Using cache file "C:\Users\Sebastian\Downloads\ts3phpframework/php-cs-fixer.cache".
```