### PR TITLE
Fix float to int conversion error

### DIFF
--- a/src/Adapter/ServerQuery.php
+++ b/src/Adapter/ServerQuery.php
@@ -250,11 +250,11 @@ class ServerQuery extends Adapter
     }
 
     /**
-     * Returns the total runtime of all queries.
+     * Returns the total runtime in microseconds of all queries.
      *
-     * @return mixed
+     * @return float
      */
-    public function getQueryRuntime(): mixed
+    public function getQueryRuntime(): float
     {
         return $this->getProfiler()->getRuntime();
     }

--- a/src/Helper/Profiler/Timer.php
+++ b/src/Helper/Profiler/Timer.php
@@ -114,11 +114,11 @@ class Timer
     }
 
     /**
-     * Return the timer runtime.
+     * Return the timer runtime in microseconds.
      *
-     * @return mixed
+     * @return float
      */
-    public function getRuntime(): mixed
+    public function getRuntime(): float
     {
         if ($this->isRunning()) {
             $this->stop();

--- a/src/Helper/Profiler/Timer.php
+++ b/src/Helper/Profiler/Timer.php
@@ -90,7 +90,7 @@ class Timer
         $this->data["realmem_start"] = memory_get_usage(true);
         $this->data["emalloc_start"] = memory_get_usage();
 
-        $this->started = microtime(true);
+        $this->started = intval(microtime(true));
         $this->running = true;
     }
 
@@ -105,7 +105,7 @@ class Timer
             return;
         }
 
-        $this->data["runtime"] += microtime(true) - $this->started;
+        $this->data["runtime"] += intval(microtime(true)) - $this->started;
         $this->data["realmem"] += memory_get_usage(true) - $this->data["realmem_start"];
         $this->data["emalloc"] += memory_get_usage() - $this->data["emalloc_start"];
 

--- a/src/Helper/Profiler/Timer.php
+++ b/src/Helper/Profiler/Timer.php
@@ -40,11 +40,11 @@ class Timer
     protected bool $running = false;
 
     /**
-     * Stores the timestamp when the timer was last started.
+     * Stores the timestamp in microseconds when the timer was last started.
      *
-     * @var integer
+     * @var float
      */
-    protected int $started = 0;
+    protected float $started = 0;
 
     /**
      * Stores the timer name.
@@ -90,7 +90,7 @@ class Timer
         $this->data["realmem_start"] = memory_get_usage(true);
         $this->data["emalloc_start"] = memory_get_usage();
 
-        $this->started = intval(microtime(true));
+        $this->started = microtime(true);
         $this->running = true;
     }
 
@@ -105,7 +105,7 @@ class Timer
             return;
         }
 
-        $this->data["runtime"] += intval(microtime(true)) - $this->started;
+        $this->data["runtime"] += microtime(true) - $this->started;
         $this->data["realmem"] += memory_get_usage(true) - $this->data["realmem_start"];
         $this->data["emalloc"] += memory_get_usage() - $this->data["emalloc_start"];
 


### PR DESCRIPTION
Fixes the following error: `Implicit conversion from float to int loses precision`

Exception:
```shell
   Whoops\Exception\ErrorException 

  Implicit conversion from float 1678058856.0934 to int loses precision

  at vendor/planetteamspeak/ts3-php-framework/src/Helper/Profiler/Timer.php:93
     89▕
     90▕         $this->data["realmem_start"] = memory_get_usage(true);
     91▕         $this->data["emalloc_start"] = memory_get_usage();
     92▕
  ➜  93▕         $this->started = microtime(true);
     94▕         $this->running = true;
     95▕     }
     96▕
     97▕     /**

      +3 vendor frames 
  4   [internal]:0
      PlanetTeamSpeak\TeamSpeak3Framework\Adapter\ServerQuery::__destruct()
```