### PR TITLE
Issue #187: Callbacks for events are not being executed

### DIFF
--- a/src/Transport/Transport.php
+++ b/src/Transport/Transport.php
@@ -218,7 +218,7 @@ abstract class Transport
         if ($this->adapter instanceof Adapter) {
             $string = StringHelper::factory(get_class($this->adapter));
 
-            return $string->substr($string->findLast("_"))->replace(["_", " "], "")->toString();
+            return $string->substr($string->findLast("\\"))->replace(["\\", " "], "")->toString();
         }
 
         return "Unknown";

--- a/tests/Transport/TransportTest.php
+++ b/tests/Transport/TransportTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PlanetTeamSpeak\TeamSpeak3Framework\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use PlanetTeamSpeak\TeamSpeak3Framework\Adapter\MockServerQuery;
+use PlanetTeamSpeak\TeamSpeak3Framework\Transport\Transport;
+
+class TransportTest extends TestCase
+{
+    /**
+     * @throws AdapterException
+     */
+    protected function createMockServerQuery(): MockServerQuery
+    {
+        return new MockServerQuery(['host' => '0.0.0.0', 'port' => 9987]);
+    }
+
+    /**
+     * @throws TransportException
+     */
+    public function testGetAdapterTypeReturnValue()
+    {
+        $mockServerQuery = $this->createMockServerQuery();
+
+        // The original value should be returned as it is
+        $this->assertEquals("MockServerQuery", $mockServerQuery->getTransport()->getAdapterType());
+
+        // The Signal class combines the lowered class name with an additional string for the `emit()` function
+        $this->assertEquals("mockserverquery", strtolower($mockServerQuery->getTransport()->getAdapterType()));
+    }
+}


### PR DESCRIPTION
# Summary

The class name now contains the full namespace path, so we need to replace the `\` instead of the `_`.

Resolves #187

# Debugging Info

```php
$ git diff src/Transport/TCP.php
diff --git a/src/Transport/TCP.php b/src/Transport/TCP.php
index 02ce50a..f19a622 100644
--- a/src/Transport/TCP.php
+++ b/src/Transport/TCP.php
@@ -153,6 +153,7 @@ class TCP extends Transport
 
             $data = @fgets($this->stream, 4096);
 
+            var_dump( strtolower($this->getAdapterType()) );
             Signal::getInstance()->emit(strtolower($this->getAdapterType()) . "DataRead", $data);
 
             if ($data === false) {
```

Before (without this fix):
```php
string(55) "planetteamspeak\teamspeak3framework\adapter\serverquery"
```

After (with this fix):
```php
string(11) "serverquery"
```

# PHPUnit Tests

Before (without this fix):
```shell
$ ./vendor/bin/phpunit --no-coverage tests/Transport/TransportTest.php 
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 00:00.088, Memory: 6.00 MB

There was 1 failure:

1) PlanetTeamSpeak\TeamSpeak3Framework\Tests\Transport\TransportTest::testGetAdapterTypeReturnValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'MockServerQuery'
+'PlanetTeamSpeak\TeamSpeak3Framework\Adapter\MockServerQuery'

C:\Users\Sebastian\Downloads\ts3phpframework\tests\Transport\TransportTest.php:27

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

After (with this fix):
```shell
$ ./vendor/bin/phpunit --no-coverage tests/Transport/TransportTest.php 
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.009, Memory: 6.00 MB

OK (1 test, 2 assertions)
```