### PR TITLE
Fix `Call to a member function toInt() on float`

### DIFF
--- a/src/Node/Channel.php
+++ b/src/Node/Channel.php
@@ -405,10 +405,7 @@ class Channel extends Node
      */
     public function iconDownload()
     {
-        $iconid = $this['channel_icon_id'];
-        if (!is_int($iconid)) {
-            $iconid = $iconid->toInt();
-        }
+        $iconid = floatval($this['channel_icon_id']);
 
         if ($this->iconIsLocal("channel_icon_id") || $iconid == 0) {
             return;

--- a/src/Node/Client.php
+++ b/src/Node/Client.php
@@ -411,10 +411,7 @@ class Client extends Node
      */
     public function iconDownload()
     {
-        $iconid = $this['client_icon_id'];
-        if (!is_int($iconid)) {
-            $iconid = $iconid->toInt();
-        }
+        $iconid = floatval($this['client_icon_id']);
 
         if ($this->iconIsLocal("client_icon_id") || $iconid == 0) {
             return;

--- a/src/Node/Group.php
+++ b/src/Node/Group.php
@@ -42,10 +42,7 @@ abstract class Group extends Node
      */
     public function iconDownload()
     {
-        $iconid = $this['iconid'];
-        if (!is_int($iconid)) {
-            $iconid = $iconid->toInt();
-        }
+        $iconid = floatval($this['iconid']);
 
         if ($this->iconIsLocal("iconid") || $iconid == 0) {
             return;

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -142,10 +142,7 @@ abstract class Node implements RecursiveIterator, ArrayAccess, Countable
      */
     public function iconIsLocal(string $key): bool
     {
-        $iconid = $this[$key];
-        if (!is_int($iconid)) {
-            $iconid = $iconid->toInt();
-        }
+        $iconid = floatval($this[$key]);
 
         return $iconid > 0 && $iconid < 1000;
     }
@@ -158,10 +155,7 @@ abstract class Node implements RecursiveIterator, ArrayAccess, Countable
      */
     public function iconGetName(string $key): StringHelper
     {
-        $iconid = $this[$key];
-        if (!is_int($iconid)) {
-            $iconid = $iconid->toInt();
-        }
+        $iconid = floatval($this[$key]);
 
         $iconid = ($iconid < 0) ? (pow(2, 32)) - ($iconid * -1) : $iconid;
 

--- a/src/Node/Server.php
+++ b/src/Node/Server.php
@@ -1839,10 +1839,7 @@ class Server extends Node
         if ($iconname) {
             $name = new StringHelper("/" . $iconname);
         } else {
-            $iconid = $this['virtualserver_icon_id'];
-            if (!is_int($iconid)) {
-                $iconid = $iconid->toInt();
-            }
+            $iconid = floatval($this['virtualserver_icon_id']);
 
             if ($this->iconIsLocal("virtualserver_icon_id") || $iconid == 0) {
                 return;


### PR DESCRIPTION
Calling e.g. `$virtualserver->getInfo(true, true))` caused the error `Call to a member function toInt() on float`.

Alternative, we could introduce a respective function like this (untested):
```php
/**
 * Returns the float value of the string.
 * @return float
 */
public function toFloat(): float
{
    return floatval($this->string);
}
```

Current value:
```php
// src/Node/Node.php:158
public function iconGetName(string $key): StringHelper
{
    dd($this[$key]);
    $iconid = floatval($this[$key]);
    [...]
}
```
```shell
3525880661.0 // vendor/planetteamspeak/ts3-php-framework/src/Node/Node.php:158
```