### PR TITLE
Remove throwing TransportException on `readLine()`

### DIFF
--- a/src/Transport/TCP.php
+++ b/src/Transport/TCP.php
@@ -158,8 +158,6 @@ class TCP extends Transport
             if ($data === false) {
                 if ($line->count()) {
                     $line->append($token);
-                } else {
-                    throw new TransportException("connection to server '" . $this->config["host"] . ":" . $this->config["port"] . "' lost");
                 }
             } else {
                 $line->append($data);


### PR DESCRIPTION
@ronindesign I am not sure, why we are throwing a `TransportException` here, if there is no data and line anymore.

I've developed a client, which stays connected and regulary executes ServerQuery commands like getting the current clientlist and in case of timeouts, it sends a keepalive 50 seconds before the timeout occurs.

However... This `else` code here always causes a `connection lost` within the first 5 seconds after connecting, when the second ServerQuery command gets executed:

```
www-data@4a53142831ba:~$ php artisan instance:start-teamspeak-bot
Starting TeamSpeak bot instance
Caching the current datetime in various formats...
Caching the current client list...
Caching the current servergroup list...

   PlanetTeamSpeak\TeamSpeak3Framework\Exception\TransportException 

  connection to server 'localhost:10022' lost

  at vendor/planetteamspeak/ts3-php-framework/src/Transport/TCP.php:162
    158▕             if ($data === false) {
    159▕                 if ($line->count()) {
    160▕                     $line->append($token);
    161▕                 } else {
  ➜ 162▕                     throw new TransportException("connection to server '" . $this->config["host"] . ":" . $this->config["port"] . "' lost");
    163▕                 }
    164▕             } else {
    165▕                 $line->append($data);
    166▕             }

      +6 vendor frames 
  7   app/Http/Controllers/Helpers/BotController.php:94
      PlanetTeamSpeak\TeamSpeak3Framework\Node\Server::serverGroupClientList()
```

I've manually removed this `else` part in my local `vendor/` directory and then everything is working as expected. I also didn't notice any bad side effects when removing this piece of code. Without this code, my client stays connected for multiple hours without any issues.

Could you please double-check this and decide, whether we can simply remove this code or if we need to fix something else?