### PR TITLE
Issue #198: Fix deprecated `utf8_encode()` and `utf8_decode()` functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "require": {
     "php": "^8.0",
+    "ext-mbstring": "*",
     "ext-json": "*",
     "ext-ctype": "*",
     "phpseclib/phpseclib": "^3.0",

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -469,7 +469,7 @@ class StringHelper implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function toUtf8(): static
     {
         if (!$this->isUtf8()) {
-            $this->string = utf8_encode($this->string);
+            $this->string = mb_convert_encoding($this->string, 'UTF-8', mb_list_encodings());
         }
 
         return $this;

--- a/tests/Helper/StringTest.php
+++ b/tests/Helper/StringTest.php
@@ -256,11 +256,11 @@ class StringTest extends TestCase
 
     public function testToUft8()
     {
-        $notUtf8 = utf8_decode("Äpfel");
+        $notUtf8 = mb_convert_encoding("Äpfel", 'ISO-8859-1', 'UTF-8');
         $stringNotUtf8 = new StringHelper($notUtf8);
         $this->assertEquals(mb_convert_encoding($notUtf8, 'UTF-8', mb_list_encodings()), $stringNotUtf8->toUtf8()->toString());
 
-        $notUtf8 = utf8_decode("¶");
+        $notUtf8 = mb_convert_encoding("¶", 'ISO-8859-1', 'UTF-8');
         $stringNotUtf8 = new StringHelper($notUtf8);
         $this->assertEquals(mb_convert_encoding($notUtf8, 'UTF-8', mb_list_encodings()), $stringNotUtf8->toUtf8()->toString());
     }

--- a/tests/Helper/StringTest.php
+++ b/tests/Helper/StringTest.php
@@ -180,7 +180,7 @@ class StringTest extends TestCase
 
     public function testIsUtf8()
     {
-        $string = new StringHelper(utf8_encode("Äpfel"));
+        $string = new StringHelper(mb_convert_encoding("Äpfel", 'UTF-8', mb_list_encodings()));
         $this->assertTrue($string->isUtf8());
 
         // Well-formed UTF-8 Byte Sequences
@@ -258,11 +258,11 @@ class StringTest extends TestCase
     {
         $notUtf8 = utf8_decode("Äpfel");
         $stringNotUtf8 = new StringHelper($notUtf8);
-        $this->assertEquals(utf8_encode($notUtf8), $stringNotUtf8->toUtf8()->toString());
+        $this->assertEquals(mb_convert_encoding($notUtf8, 'UTF-8', mb_list_encodings()), $stringNotUtf8->toUtf8()->toString());
 
         $notUtf8 = utf8_decode("¶");
         $stringNotUtf8 = new StringHelper($notUtf8);
-        $this->assertEquals(utf8_encode($notUtf8), $stringNotUtf8->toUtf8()->toString());
+        $this->assertEquals(mb_convert_encoding($notUtf8, 'UTF-8', mb_list_encodings()), $stringNotUtf8->toUtf8()->toString());
     }
 
     public function testToBase64()


### PR DESCRIPTION
```shell
$ php vendor/bin/phpunit --no-coverage tests/Helper/StringTest.php 
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

............................                                      28 / 28 (100%)

Time: 00:00.017, Memory: 6.00 MB

OK (28 tests, 86 assertions)
```

See https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated for further information.

Closes #198