### PR TITLE
Issue #194: Fix incompatible float to int conversion

### DIFF
--- a/src/Helper/Convert.php
+++ b/src/Helper/Convert.php
@@ -24,6 +24,7 @@
 
 namespace PlanetTeamSpeak\TeamSpeak3Framework\Helper;
 
+use DateTime;
 use PlanetTeamSpeak\TeamSpeak3Framework\TeamSpeak3;
 
 /**
@@ -85,13 +86,16 @@ class Convert
      * @todo: Handle negative integer $seconds, or invalidate
      *
      */
-    public static function seconds(int $seconds, bool $is_ms = false, string $format = "%dD %02d:%02d:%02d"): string
+    public static function seconds(int $seconds, bool $is_ms = false, string $format = "%aD %H:%I:%S"): string
     {
         if ($is_ms) {
             $seconds = $seconds / 1000;
         }
 
-        return sprintf($format, $seconds / 60 / 60 / 24, ($seconds / 60 / 60) % 24, ($seconds / 60) % 60, $seconds % 60);
+        $current_datetime = new DateTime("@0");
+        $seconds_datetime = new DateTime("@$seconds");
+
+        return $current_datetime->diff($seconds_datetime)->format($format);
     }
 
     /**

--- a/tests/Helper/ConvertTest.php
+++ b/tests/Helper/ConvertTest.php
@@ -173,6 +173,10 @@ class ConvertTest extends TestCase
         $this->assertEquals('1D 23:59:59', $output);
         $this->assertIsString($output);
 
+        $output = Convert::seconds(90.083);
+        $this->assertEquals('0D 00:01:30', $output);
+        $this->assertIsString($output);
+
         // @todo: Enable after ::seconds() can handle negative integers
         //$output = Convert::seconds(-1);
         //$this->assertEquals('-0D 00:00:01', $output);


### PR DESCRIPTION
Simplifies the conversion of seconds to a human readable format by using a PHP built-in function. This also solves the conversion problem reported in the issue #194.

See https://www.php.net/manual/de/class.datetime.php and https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string for further information.

Closes #194