### PR TITLE
Add ServerQuery Reply tests and improve exception message

### DIFF
--- a/src/Adapter/ServerQuery/Reply.php
+++ b/src/Adapter/ServerQuery/Reply.php
@@ -203,7 +203,7 @@ class Reply
             if (isset($node[$ident])) {
                 $array[(is_object($node[$ident])) ? $node[$ident]->toString() : $node[$ident]] = $node;
             } else {
-                throw new ServerQueryException("invalid parameter", 0x602);
+                throw new ServerQueryException("invalid parameter. ident '$ident' does not exist in node '".json_encode($node)."'", 0x602);
             }
         }
 

--- a/tests/Adapter/ServerQuery/ReplyTest.php
+++ b/tests/Adapter/ServerQuery/ReplyTest.php
@@ -53,12 +53,12 @@ class ReplyTest extends TestCase
      */
     public function testConstructor()
     {
-      $reply = new Reply([
-        new StringHelper(static::$S_SERVERLIST),
-        new StringHelper(static::$S_ERROR_OK)
-      ]);
+        $reply = new Reply([
+          new StringHelper(static::$S_SERVERLIST),
+          new StringHelper(static::$S_ERROR_OK)
+        ]);
 
-      $this->assertInstanceOf(Reply::class, $reply);
+        $this->assertInstanceOf(Reply::class, $reply);
     }
 
     /**
@@ -67,12 +67,12 @@ class ReplyTest extends TestCase
      */
     public function testToString()
     {
-      $reply = new Reply([
-        new StringHelper(static::$S_SERVERLIST),
-        new StringHelper(static::$S_ERROR_OK)
-      ]);
+        $reply = new Reply([
+          new StringHelper(static::$S_SERVERLIST),
+          new StringHelper(static::$S_ERROR_OK)
+        ]);
 
-      $this->assertEquals(static::$E_SERVERLIST, (string) $reply->toString());
+        $this->assertEquals(static::$E_SERVERLIST, (string) $reply->toString());
     }
 
     public function testToLines()
@@ -87,21 +87,21 @@ class ReplyTest extends TestCase
      */
     public function testToArray()
     {
-      $reply = new Reply([
-        new StringHelper(static::$S_CLIENTLIST_EXTENDED_SINGLE),
-        new StringHelper(static::$S_ERROR_OK)
-      ]);
+        $reply = new Reply([
+          new StringHelper(static::$S_CLIENTLIST_EXTENDED_SINGLE),
+          new StringHelper(static::$S_ERROR_OK)
+        ]);
 
-      $clientlist_array = $reply->toArray('clid')[0];
+        $clientlist_array = $reply->toArray('clid')[0];
 
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLID, (string) $clientlist_array['clid']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_NICKNAME, (string) $clientlist_array['client_nickname']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_AWAY_MESSAGE, (string) $clientlist_array['client_away_message']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_FLAG_TALKING, (string) $clientlist_array['client_flag_talking']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_UNIQUE_IDENTIFIER, (string) $clientlist_array['client_unique_identifier']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_SERVERGROUPS, (string) $clientlist_array['client_servergroups']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_VERSION, (string) $clientlist_array['client_version']);
-      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_BADGES, (string) $clientlist_array['client_badges']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLID, (string) $clientlist_array['clid']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_NICKNAME, (string) $clientlist_array['client_nickname']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_AWAY_MESSAGE, (string) $clientlist_array['client_away_message']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_FLAG_TALKING, (string) $clientlist_array['client_flag_talking']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_UNIQUE_IDENTIFIER, (string) $clientlist_array['client_unique_identifier']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_SERVERGROUPS, (string) $clientlist_array['client_servergroups']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_VERSION, (string) $clientlist_array['client_version']);
+        $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_BADGES, (string) $clientlist_array['client_badges']);
     }
 
     public function testToAssocArray()

--- a/tests/Adapter/ServerQuery/ReplyTest.php
+++ b/tests/Adapter/ServerQuery/ReplyTest.php
@@ -53,10 +53,12 @@ class ReplyTest extends TestCase
      */
     public function testConstructor()
     {
-        $reply = new Reply([
-      new StringHelper(static::$S_SERVERLIST),
-      new StringHelper(static::$S_ERROR_OK)
-    ]);
+      $reply = new Reply([
+        new StringHelper(static::$S_SERVERLIST),
+        new StringHelper(static::$S_ERROR_OK)
+      ]);
+
+      $this->assertInstanceOf(Reply::class, $reply);
     }
 
     /**

--- a/tests/Adapter/ServerQuery/ReplyTest.php
+++ b/tests/Adapter/ServerQuery/ReplyTest.php
@@ -65,11 +65,12 @@ class ReplyTest extends TestCase
      */
     public function testToString()
     {
-        $reply = new Reply([
-      new StringHelper(static::$S_SERVERLIST),
-      new StringHelper(static::$S_ERROR_OK)
-    ]);
-        $this->assertEquals(static::$E_SERVERLIST, (string)$reply->toString());
+      $reply = new Reply([
+        new StringHelper(static::$S_SERVERLIST),
+        new StringHelper(static::$S_ERROR_OK)
+      ]);
+
+      $this->assertEquals(static::$E_SERVERLIST, (string) $reply->toString());
     }
 
     public function testToLines()

--- a/tests/Adapter/ServerQuery/ReplyTest.php
+++ b/tests/Adapter/ServerQuery/ReplyTest.php
@@ -36,6 +36,17 @@ class ReplyTest extends TestCase
 
     private static string $S_CHANNELLIST = 'cid=1 pid=0 channel_order=0 channel_name=Default\sChannel total_clients=3 channel_needed_subscribe_power=0|cid=2 pid=1 channel_order=0 channel_name=Test\sParent\s1 total_clients=0 channel_needed_subscribe_power=0|cid=3 pid=1 channel_order=2 channel_name=Test\sParent\s2 total_clients=0 channel_needed_subscribe_power=0|cid=5 pid=3 channel_order=0 channel_name=P2\s-\sSub\s1 total_clients=0 channel_needed_subscribe_power=0|cid=6 pid=3 channel_order=5 channel_name=P2\s-\sSub\s2 total_clients=0 channel_needed_subscribe_power=0|cid=4 pid=1 channel_order=3 channel_name=Test\sParent\s3 total_clients=0 channel_needed_subscribe_power=0|cid=7 pid=4 channel_order=0 channel_name=P3\s-\sSub\s1 total_clients=0 channel_needed_subscribe_power=0|cid=8 pid=4 channel_order=7 channel_name=P3\s-\sSub\s2 total_clients=0 channel_needed_subscribe_power=0';
 
+    // `clientlist` command with all parameters (single client)
+    private static string $S_CLIENTLIST_EXTENDED_SINGLE = "clid=63 cid=53 client_database_id=25 client_nickname=HouseMaister-Radio\sBob\s(Rock) client_type=0 client_away=0 client_away_message client_flag_talking=0 client_input_muted=0 client_output_muted=0 client_input_hardware=1 client_output_hardware=1 client_talk_power=70 client_is_talker=0 client_is_priority_speaker=0 client_is_recording=0 client_is_channel_commander=0 client_unique_identifier=7seVjHY4Hbe2cSxTjyv8es7wv54= client_servergroups=147,227 client_channel_group_id=13 client_channel_group_inherited_channel_id=53 client_version=3.5.6\s[Build:\s1606312422] client_platform=Linux client_idle_time=102752 client_created=1684051977 client_lastconnected=1691241932 client_icon_id=0 client_country=DE connection_client_ip=fe80::9400:ff:fe2b::1 client_badges=Overwolf=1:badges=c2368518-3728-4260-bcd1-8b85e9f8984c";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLID = "63";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_NICKNAME = "HouseMaister-Radio\sBob\s(Rock)";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_AWAY_MESSAGE = "";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_FLAG_TALKING = "0";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_UNIQUE_IDENTIFIER = "7seVjHY4Hbe2cSxTjyv8es7wv54=";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_SERVERGROUPS = "147,227";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_VERSION = "3.5.6\s[Build:\s1606312422]";
+    private static string $E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_BADGES = "Overwolf=1:badges=c2368518-3728-4260-bcd1-8b85e9f8984c";
+
     /**
      * @throws AdapterException
      * @throws ServerQueryException
@@ -67,9 +78,29 @@ class ReplyTest extends TestCase
     public function testToTable()
     {
     }
+
+    /**
+     * Tests the toArray() function
+     */
     public function testToArray()
     {
+      $reply = new Reply([
+        new StringHelper(static::$S_CLIENTLIST_EXTENDED_SINGLE),
+        new StringHelper(static::$S_ERROR_OK)
+      ]);
+
+      $clientlist_array = $reply->toArray('clid')[0];
+
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLID, (string) $clientlist_array['clid']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_NICKNAME, (string) $clientlist_array['client_nickname']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_AWAY_MESSAGE, (string) $clientlist_array['client_away_message']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_FLAG_TALKING, (string) $clientlist_array['client_flag_talking']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_UNIQUE_IDENTIFIER, (string) $clientlist_array['client_unique_identifier']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_SERVERGROUPS, (string) $clientlist_array['client_servergroups']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_VERSION, (string) $clientlist_array['client_version']);
+      $this->assertEquals(static::$E_CLIENTLIST_EXTENDED_SINGLE_CLIENT_BADGES, (string) $clientlist_array['client_badges']);
     }
+
     public function testToAssocArray()
     {
     }


### PR DESCRIPTION
Improves the `ServerQueryException` message to be better able to identify the actual root cause.

Before:
```shell
PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException^ {#3929 // app/Http/Controllers/TeamSpeak.php:65
  #message: "invalid parameter"
  #code: 1538
  #file: "./vendor/planetteamspeak/ts3-php-framework/src/Adapter/ServerQuery/Reply.php"
  #line: 206
  #raw_code: 1538
  #raw_mesg: "invalid parameter"
  #return_code: null
  trace: {
    ./vendor/planetteamspeak/ts3-php-framework/src/Adapter/ServerQuery/Reply.php:206 { …}
    ./vendor/planetteamspeak/ts3-php-framework/src/Node/Server.php:633 { …}
    ./app/Http/Controllers/TeamSpeak.php:63 {
      App\Http\Controllers\TeamSpeak->get_current_client_list(): array^
      › try {
      ›     $client_list = $this->virtualserver->clientList(["client_type" => 0]);
      › } catch (ServerQueryException $ex) {
      arguments: {
        $filter: array:1 [ …1]
      }
    }
    [...]
```

After:
```shell
PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException^ {#3929 // app/Http/Controllers/TeamSpeak.php:65
  #message: "invalid parameter. ident 'clid' does not exist in node '{"put_muted":0,"client_output_muted":0,"client_input_hardware":1,"client_output_hardware":1,"client_talk_power":70,"client_is_talker":0,"client_is_priority_speaker":0,"client_is_recording":0,"client_is_channel_commander":0,"client_unique_identifier":"zBbdjIImKqM\/v18taBCdXhmoN4A=","client_servergroups":"137,146,147,261","client_channel_group_id":13,"client_channel_group_inherited_channel_id":108,"client_version":"3.5.6 [Build: 1606312422]","client_platform":"Linux","client_idle_time":117403360,"client_created":1684050729,"client_icon_id":0,"client_country":"DE",_icon_id":0,"client_country":"DE","connection_client_ip":"fe80::9400:ff:fe2b::1","client_badges":null}'"
  #code: 1538
  #file: "./vendor/planetteamspeak/ts3-php-framework/src/Adapter/ServerQuery/Reply.php"
  #line: 206
  #raw_code: 1538
  #raw_mesg: "invalid parameter. ident 'clid' does not exist in node '{"put_muted":0,"client_output_muted":0,"client_input_hardware":1,"client_output_hardware":1,"client_talk_power":70,"client_is_talker":0,"client_is_priority_speaker":0,"client_is_recording":0,"client_is_channel_commander":0,"client_unique_identifier":"zBbdjIImKqM\/v18taBCdXhmoN4A=","client_servergroups":"137,146,147,261","client_channel_group_id":13,"client_channel_group_inherited_channel_id":108,"client_version":"3.5.6 [Build: 1606312422]","client_platform":"Linux","client_idle_time":117403360,"client_created":1684050729,"client_lastconnected":1691241638,"client_icon_id":0,"client_country":"DE","connection_client_ip":"fe80::9400:ff:fe2b::1","client_badges":null}'"
  #return_code: null
  trace: {
    ./vendor/planetteamspeak/ts3-php-framework/src/Adapter/ServerQuery/Reply.php:206 { …}
    ./vendor/planetteamspeak/ts3-php-framework/src/Node/Server.php:633 { …}
    ./app/Http/Controllers/TeamSpeak.php:63 {
      App\Http\Controllers\TeamSpeak->get_current_client_list(): array^
      › try {
      ›     $client_list = $this->virtualserver->clientList(["client_type" => 0]);
      › } catch (ServerQueryException $ex) {
      arguments: {
        $filter: array:1 [ …1]
      }
    }
    [...]
```

Adds some further PHPUnit tests.