### PR TITLE
Issue #204: Fix high CPU utilization after disconnects / connection losses

### DIFF
--- a/src/Adapter/ServerQuery.php
+++ b/src/Adapter/ServerQuery.php
@@ -100,6 +100,11 @@ class ServerQuery extends Adapter
      */
     public function __destruct()
     {
+        // do not disconnect, when acting as bot in non-blocking mode
+        if (! $this->getTransport()->getConfig("blocking")) {
+            return;
+        }
+
         if ($this->getTransport() instanceof Transport && $this->transport->isConnected()) {
             try {
                 $this->request("quit");

--- a/src/Adapter/ServerQuery.php
+++ b/src/Adapter/ServerQuery.php
@@ -137,6 +137,9 @@ class ServerQuery extends Adapter
         $rpl = [];
 
         do {
+            if (! $this->getTransport()->isConnected()) {
+                break;
+            }
             $str = $this->getTransport()->readLine();
             $rpl[] = $str;
         } while ($str->section(TeamSpeak3::SEPARATOR_CELL) != TeamSpeak3::ERROR);
@@ -163,6 +166,9 @@ class ServerQuery extends Adapter
         }
 
         do {
+            if (! $this->getTransport()->isConnected()) {
+                break;
+            }
             $evt = $this->getTransport()->readLine();
         } while (!$evt->section(TeamSpeak3::SEPARATOR_CELL)->startsWith(TeamSpeak3::EVENT));
 

--- a/src/Transport/Transport.php
+++ b/src/Transport/Transport.php
@@ -246,7 +246,7 @@ abstract class Transport
      */
     public function isConnected(): bool
     {
-        return is_resource($this->stream);
+        return ($this->getStream() === null) ? false : true;
     }
 
     /**

--- a/tests/Transport/TCPTest.php
+++ b/tests/Transport/TCPTest.php
@@ -3,6 +3,7 @@
 namespace PlanetTeamSpeak\TeamSpeak3Framework\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use PlanetTeamSpeak\TeamSpeak3Framework\Adapter\MockServerQuery;
 use PlanetTeamSpeak\TeamSpeak3Framework\Adapter\ServerQuery;
 use PlanetTeamSpeak\TeamSpeak3Framework\Exception\ServerQueryException;
 use PlanetTeamSpeak\TeamSpeak3Framework\Transport\TCP;
@@ -89,6 +90,25 @@ class TCPTest extends TestCase
             ['host' => 'test', 'port' => 12345]
         );
         $this->assertNull($transport->getStream());
+    }
+
+    /**
+     * @throws AdapterException
+     */
+    protected function createMockServerQuery(): MockServerQuery
+    {
+        return new MockServerQuery(['host' => '0.0.0.0', 'port' => 9987]);
+    }
+
+    /**
+     * Tests if the connection status gets properly returned.
+     */
+    public function testConnectionStatus()
+    {
+        $mockServerQuery = $this->createMockServerQuery();
+        $this->assertTrue($mockServerQuery->getTransport()->isConnected());
+        $mockServerQuery->getTransport()->disconnect();
+        $this->assertFalse($mockServerQuery->getTransport()->isConnected());
     }
 
     /**


### PR DESCRIPTION
Changes:

- Do not automatically close the connection when `blocking=0` (non-blocking mode)
- Properly exit loops after disconnects / connection losses

Before (without this change):

- Aborting an e. g. TeamSpeak bot script resulted most of the time in a stuck script, which never finished / exited
- Loosing the connection to the TeamSpeak server resulted most of the time in an endless loop, which caused a lot of disk I/O: `pselect6(13, [12], [], [], {tv_sec=10, tv_nsec=0}, NULL) = 1 (in [12], left {tv_sec=9, tv_nsec=999998860})` (see https://linux.die.net/man/2/pselect6)
- PHP script caused a very high CPU utilization (95-130 % on a single core system)

After (with this change):

- Aborting an e. g. TeamSpeak bot script properly finishes / exits the script immediately (NOT stuck anymore)
- Loosing the connection to the TeamSpeak server properly finishes / exits the script immediately (NO endless loop anymore and thus no disk I/O anymore)
- PHP script does NOT cause any high CPU utilization anymore

Closes #204