### PR TITLE
#213 Improve and fix URI parsing

### DIFF
--- a/tests/Helper/UriTest.php
+++ b/tests/Helper/UriTest.php
@@ -449,7 +449,6 @@ class UriTest extends TestCase
      */
     public function testGetQuery(Uri $uri)
     {
-        // NOTE: getPath() is never used in framework, add tests for consistency.
         $this->assertEquals(
             ['server_port' => '9987', 'blocking' => '0'],
             $uri->getQuery()


### PR DESCRIPTION
- Fix `Call to a member function toString() on null` when using `factory()` without credentials
- Allows `factory()` without username and password
- Use PHP native `parse_url()` function to simplify code
- Improve and refactor some validations in general
- Adjust and extend PHPUnit tests

closes #213