### PR TITLE
Update StringHelper to avoid converting int's encoding to utf8

### DIFF
--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -468,7 +468,7 @@ class StringHelper implements ArrayAccess, Iterator, Countable, JsonSerializable
      */
     public function toUtf8(): static
     {
-        if (!$this->isUtf8()) {
+        if (!$this->isUtf8() && !$this->isInt()) {
             $this->string = mb_convert_encoding($this->string, 'UTF-8', mb_list_encodings());
         }
 


### PR DESCRIPTION
Hi together,

I recently hit an problem with the latest version (1.3.0) & with dev branch.
If I select an server by id and the serverId is 11+ it results in an convert error,

After some research I found out that using mb_convert_encoding on 11-19 result in some weird characters like ㄱ as 11 or ㄹ as 19 🤣

I assume that will fix https://github.com/planetteamspeak/ts3phpframework/issues/212.